### PR TITLE
Modify some ST entries to follow SAT and SARO guidelines

### DIFF
--- a/IT-ST.tex
+++ b/IT-ST.tex
@@ -792,11 +792,12 @@ Usuarios, administración y autenticación con Django.
  \item \textbf{Material:} Guión \url{https://gsyc.urjc.es/grex/cursosweb/guion5.html}
  \item \textbf{Material:} Transparencias ``Introducción a Django''
  \item \textbf{Ejercicio (discusión en clase):} ``Django cms\_post'' (ejercicio~\ref{subsec:django-post}).
-  Entrega recomendada: antes del \juevesL.
+  Entrega recomendada: antes del \juevesM.
 %    \item \textbf{Material:} Documentación de Django: ``Working with forms'' \\
 %          \url{http://docs.djangoproject.com/en/1.4/topics/forms}
 %  \item \textbf{Ejercicio voluntario:} ``Django feed\_expander'' (ejercicio~\ref{subsec:django-feed-expander}).
 %  \item \textbf{Presentación:} proyecto final (enunciado~\ref{practica-final-2019-05})
+  \item \textbf{Presentación:} Práctica final (apartado~\ref{practica-final-2022-05})
 \end{itemize}
 
 %%%----------------------------------------------------------------------------
@@ -806,7 +807,9 @@ Usuarios, administración y autenticación con Django.
 \begin{itemize}
   \item \textbf{Presentación:} Introducción a Django (formularios)
   \item \textbf{Ejercicio:} ``Django cms\_forms'' (ejercicio~\ref{subsec:django-forms}) \\
-  \item \textbf{Presentación:} Práctica final (apartado~\ref{practica-final-2021-05})
+  \item \textbf{Ejercicio:} ``Django cms\_bootstrap cuadrícula'' (ejercicio~\ref{subsec:django-cms-bootstrap-1})
+  \item \textbf{Ejercicio:} ``Django cms\_bootstrap componentes'' (ejercicio~\ref{subsec:django-cms-bootstrap-2})
+  \item \textbf{Ejercicio:} ``Django cms\_bootstrap componentes personalizados'' (ejercicio~\ref{subsec:django-cms-bootstrap-3})
   \end{itemize}
 
 

--- a/ejercicios-web.tex
+++ b/ejercicios-web.tex
@@ -113,9 +113,7 @@ Se recomienda realizar la aplicación en varios pasos:
 \subsection{Minipráctica 2 (entrega voluntaria)}
 \label{subsec:practica-vol-2-2015}
 
-\textbf{Fecha recomendada de entrega para SAT y SARO:} Hasta el 7 de abril.
-
-\textbf{Fecha recomendada de entrega para ST:} Hasta el 4 de abril .
+\textbf{Fecha recomendada de entrega para SAT, ST y SARO:} Hasta el 7 de abril.
 
 Esta práctica tendrá como objetivo la creación de una aplicación web (de nombre \emph{acorta}) simple para acortar URLs utilizando Django (en un nuevo proyecto Django llamado \emph{project}). Su enunciado será igual que el de la práctica 1 de entrega voluntaria (ejercicio~\ref{subsec:minipractica-1-2022}), salvo en los siguientes aspectos:
 


### PR DESCRIPTION
This commit includes the following changes:
 - Update "practica final" to the one of this year
 - "Practica final" is now in the Django VI lesson
 - Add missing content in Django VII
 - Fix some date missmatch in "Minipractica 2"
 - Fix date of "django-post" exercise, since the date was the same day of the lesson.
